### PR TITLE
add getWebContainerSVG

### DIFF
--- a/dev/popup.js
+++ b/dev/popup.js
@@ -84,6 +84,11 @@ function getSymbols() {
   return document.getElementById('FxSymbolContainer');
 }
 
+/**
+ * Retrieves all SVG elements within the document.
+ *
+ * @returns {Array<SVGElement>} An array of SVG elements.
+ */
 function getWebContainerSVG() {
   return Array.from(document.querySelectorAll('svg'));
 }

--- a/dev/popup.js
+++ b/dev/popup.js
@@ -76,8 +76,16 @@ async function getCurrentTab() {
   return tab;
 }
 
+/**
+ * Retrieves the element with the ID 'FxSymbolContainer'.
+ * @returns {HTMLElement} The element with the ID 'FxSymbolContainer'.
+ */
 function getSymbols() {
   return document.getElementById('FxSymbolContainer');
+}
+
+function getWebContainerSVG() {
+  return Array.from(document.querySelectorAll('svg'));
 }
 
 async function getIcons() {
@@ -89,7 +97,8 @@ async function getIcons() {
 
   let symbols = getSymbols();
   // console.log(symbols);
-  let webContainerSVG = Array.from(document.querySelectorAll('svg'));
+
+  let webContainerSVG = getWebContainerSVG();
   // console.log(webContainerSVG);
 
   // find img tags with .svg

--- a/dev/popup.js
+++ b/dev/popup.js
@@ -711,4 +711,5 @@ module.exports = {
   getSymbols,
   showURLErrorMessage,
   getCurrentTab,
+  getWebContainerSVG,
 };

--- a/dev/popup.test.js
+++ b/dev/popup.test.js
@@ -1,7 +1,8 @@
 const popup = require('./popup');
 const fetchMock = require('fetch-mock-jest');
 
-const { getSymbols, showURLErrorMessage, getCurrentTab } = popup;
+const { getSymbols, showURLErrorMessage, getCurrentTab, getWebContainerSVG } =
+  popup;
 
 describe('getSymbols', () => {
   beforeEach(() => {

--- a/dev/popup.test.js
+++ b/dev/popup.test.js
@@ -65,3 +65,19 @@ describe('getCurrentTab', () => {
     expect(result).toBe(expectedTab);
   });
 });
+
+describe('getWebContainerSVG', () => {
+  it('should return an array of SVG elements', () => {
+    // Arrange
+    const svgElement1 = document.createElement('svg');
+    const svgElement2 = document.createElement('svg');
+    document.body.appendChild(svgElement1);
+    document.body.appendChild(svgElement2);
+
+    // Act
+    const result = getWebContainerSVG();
+
+    // Assert
+    expect(result).toEqual([svgElement1, svgElement2]);
+  });
+});


### PR DESCRIPTION
This pull request primarily focuses on the `dev/popup.js` file, introducing a new function `getWebContainerSVG()` which retrieves all SVG elements within the document. This function is then utilized in the `getIcons()` function, replacing a previous direct call to `document.querySelectorAll('svg')`. The new function is also exported in the `module.exports` section. Additionally, a new test has been added in `dev/popup.test.js` to ensure that `getWebContainerSVG()` works as expected.

Here are the key changes:

* [`dev/popup.js`](diffhunk://#diff-5dd7e6f389caa90c0a93cfa8a86304e72bf4d07d66963acec9c432c8b92794dbR79-R95): Introduced a new function `getWebContainerSVG()` that retrieves all SVG elements within the document. This function is then used in the `getIcons()` function. [[1]](diffhunk://#diff-5dd7e6f389caa90c0a93cfa8a86304e72bf4d07d66963acec9c432c8b92794dbR79-R95) [[2]](diffhunk://#diff-5dd7e6f389caa90c0a93cfa8a86304e72bf4d07d66963acec9c432c8b92794dbL92-R106)
* [`dev/popup.js`](diffhunk://#diff-5dd7e6f389caa90c0a93cfa8a86304e72bf4d07d66963acec9c432c8b92794dbR714): The new `getWebContainerSVG()` function is now exported in the `module.exports` section.
* [`dev/popup.test.js`](diffhunk://#diff-a6f2b87f3271f8a8cf9986ba6b4f5dd6d9211e05bb3762236ebbbaa30d3bf903R68-R83): Added a new test for the `getWebContainerSVG()` function, ensuring it returns an array of SVG elements.