### PR TITLE
Add findSVGURLs

### DIFF
--- a/dev/popup.js
+++ b/dev/popup.js
@@ -122,7 +122,7 @@ async function getIcons() {
   // console.log(webContainerSVG);
 
   let svgURLs = findSVGURLs();
-   // console.log(svgURLs);
+  // console.log(svgURLs);
 
   // Define the fetchDocument function
   async function fetchDocument(url) {

--- a/dev/popup.js
+++ b/dev/popup.js
@@ -93,6 +93,21 @@ function getWebContainerSVG() {
   return Array.from(document.querySelectorAll('svg'));
 }
 
+/**
+ * Finds and returns an array of URLs for SVG images from the current document.
+ * @returns {Array} An array of URLs for SVG images.
+ */
+function findSVGURLs() {
+  let imageTags = Array.from(document.querySelectorAll('img'));
+  let svgURLs = [];
+  svgURLs = imageTags.filter((node) => {
+    if (node.src.includes('.svg')) {
+      return node;
+    }
+  });
+  return svgURLs;
+}
+
 async function getIcons() {
   // console.log(`\n\ngetIcons - START`);
 
@@ -106,16 +121,8 @@ async function getIcons() {
   let webContainerSVG = getWebContainerSVG();
   // console.log(webContainerSVG);
 
-  // find img tags with .svg
-  let imageTags = Array.from(document.querySelectorAll('img'));
-  let svgURLs = [];
-  svgURLs = imageTags.filter((node) => {
-    if (node.src.includes('.svg')) {
-      return node;
-    }
-  });
-
-  // console.log(svgURLs);
+  let svgURLs = findSVGURLs();
+   // console.log(svgURLs);
 
   // Define the fetchDocument function
   async function fetchDocument(url) {
@@ -712,4 +719,5 @@ module.exports = {
   showURLErrorMessage,
   getCurrentTab,
   getWebContainerSVG,
+  findSVGURLs,
 };

--- a/dev/popup.test.js
+++ b/dev/popup.test.js
@@ -1,8 +1,13 @@
 const popup = require('./popup');
 const fetchMock = require('fetch-mock-jest');
 
-const { getSymbols, showURLErrorMessage, getCurrentTab, getWebContainerSVG, findSVGURLs} =
-  popup;
+const {
+  getSymbols,
+  showURLErrorMessage,
+  getCurrentTab,
+  getWebContainerSVG,
+  findSVGURLs,
+} = popup;
 
 describe('getSymbols', () => {
   beforeEach(() => {

--- a/dev/popup.test.js
+++ b/dev/popup.test.js
@@ -1,7 +1,7 @@
 const popup = require('./popup');
 const fetchMock = require('fetch-mock-jest');
 
-const { getSymbols, showURLErrorMessage, getCurrentTab, getWebContainerSVG } =
+const { getSymbols, showURLErrorMessage, getCurrentTab, getWebContainerSVG, findSVGURLs} =
   popup;
 
 describe('getSymbols', () => {
@@ -77,6 +77,42 @@ describe('getWebContainerSVG', () => {
 
     // Act
     const result = getWebContainerSVG();
+
+    // Assert
+    expect(result).toEqual([svgElement1, svgElement2]);
+  });
+});
+
+describe('findSVGURLs', () => {
+  beforeEach(() => {
+    // Reset the document body before each test
+    document.body.innerHTML = '';
+  });
+
+  it('should return an empty array if no SVG URLs are found', () => {
+    // Act
+    const result = findSVGURLs();
+
+    // Assert
+    expect(result).toEqual([]);
+  });
+
+  it('should return an array of SVG URLs', () => {
+    // Arrange
+    const svgElement1 = document.createElement('img');
+    svgElement1.src = 'image1.svg';
+    document.body.appendChild(svgElement1);
+
+    const svgElement2 = document.createElement('img');
+    svgElement2.src = 'image2.svg';
+    document.body.appendChild(svgElement2);
+
+    const nonSvgElement = document.createElement('img');
+    nonSvgElement.src = 'image3.png';
+    document.body.appendChild(nonSvgElement);
+
+    // Act
+    const result = findSVGURLs();
 
     // Assert
     expect(result).toEqual([svgElement1, svgElement2]);


### PR DESCRIPTION
This pull request primarily focuses on refactoring and improving the code in the `dev/popup.js` file, specifically around the handling of SVG URLs. The changes involve extracting a new function `findSVGURLs` from the existing `getIcons` function, and making corresponding adjustments in the tests and exports. 

Here are the key changes:

Code Refactoring:

* [`dev/popup.js`](diffhunk://#diff-5dd7e6f389caa90c0a93cfa8a86304e72bf4d07d66963acec9c432c8b92794dbR96-R110): A new function `findSVGURLs` has been added, which finds and returns an array of URLs for SVG images from the current document. This function was previously part of `getIcons`, but has been extracted for better code organization and reusability.

Code Simplification:

* [`dev/popup.js`](diffhunk://#diff-5dd7e6f389caa90c0a93cfa8a86304e72bf4d07d66963acec9c432c8b92794dbL109-R124): In the `getIcons` function, the code to find SVG URLs has been replaced with a call to the new `findSVGURLs` function, simplifying the `getIcons` function.

Exports and Tests:

* [`dev/popup.js`](diffhunk://#diff-5dd7e6f389caa90c0a93cfa8a86304e72bf4d07d66963acec9c432c8b92794dbR722): The new `findSVGURLs` function has been added to the module exports, making it available for use in other modules.
* [`dev/popup.test.js`](diffhunk://#diff-a6f2b87f3271f8a8cf9986ba6b4f5dd6d9211e05bb3762236ebbbaa30d3bf903L4-R10): The import statement has been updated to include the new `findSVGURLs` function. Additionally, new tests have been added to verify the correct functioning of `findSVGURLs`. [[1]](diffhunk://#diff-a6f2b87f3271f8a8cf9986ba6b4f5dd6d9211e05bb3762236ebbbaa30d3bf903L4-R10) [[2]](diffhunk://#diff-a6f2b87f3271f8a8cf9986ba6b4f5dd6d9211e05bb3762236ebbbaa30d3bf903R90-R125)