### PR TITLE
add fetchDocument

### DIFF
--- a/dev/popup.js
+++ b/dev/popup.js
@@ -108,6 +108,19 @@ function findSVGURLs() {
   return svgURLs;
 }
 
+/**
+ * Fetches a document from the specified URL and returns it as an SVG document.
+ * @param {string} url - The URL of the document to fetch.
+ * @returns {Promise<Document>} - A promise that resolves to the fetched SVG document.
+ */
+async function fetchDocument(url) {
+  let response = await fetch(url, { mode: 'no-cors' });
+  let text = await response.text();
+  let parser = new DOMParser();
+  let svgdocument = parser.parseFromString(text, 'image/svg+xml');
+  return svgdocument;
+}
+
 async function getIcons() {
   // console.log(`\n\ngetIcons - START`);
 
@@ -123,15 +136,6 @@ async function getIcons() {
 
   let svgURLs = findSVGURLs();
   // console.log(svgURLs);
-
-  // Define the fetchDocument function
-  async function fetchDocument(url) {
-    let response = await fetch(url, { mode: 'no-cors' });
-    let text = await response.text();
-    let parser = new DOMParser();
-    let svgdocument = parser.parseFromString(text, 'image/svg+xml');
-    return svgdocument;
-  }
 
   // Wait for all the fetches to complete
   await Promise.all(
@@ -720,4 +724,5 @@ module.exports = {
   getCurrentTab,
   getWebContainerSVG,
   findSVGURLs,
+  fetchDocument,
 };

--- a/dev/popup.test.js
+++ b/dev/popup.test.js
@@ -7,6 +7,7 @@ const {
   getCurrentTab,
   getWebContainerSVG,
   findSVGURLs,
+  fetchDocument,
 } = popup;
 
 describe('getSymbols', () => {
@@ -121,5 +122,32 @@ describe('findSVGURLs', () => {
 
     // Assert
     expect(result).toEqual([svgElement1, svgElement2]);
+  });
+});
+
+describe('fetchDocument', () => {
+  beforeEach(() => {
+    // Reset the fetch mock before each test
+    fetchMock.reset();
+  });
+
+  it('should fetch the document and return the parsed SVG document', async () => {
+    // Arrange
+    const url = 'https://example.com/image.svg';
+    const mockResponse = '<svg><circle cx="50" cy="50" r="40" /></svg>';
+    fetchMock.mock(url, mockResponse);
+
+    // Act
+    const result = await fetchDocument(url);
+
+    // Assert
+    expect(fetchMock).toHaveBeenCalledWith(url, { mode: 'no-cors' });
+    expect(result).toBeInstanceOf(Document);
+    expect(result.documentElement.tagName).toBe('svg');
+    expect(result.documentElement.children.length).toBe(1);
+    expect(result.documentElement.children[0].tagName).toBe('circle');
+    expect(result.documentElement.children[0].getAttribute('cx')).toBe('50');
+    expect(result.documentElement.children[0].getAttribute('cy')).toBe('50');
+    expect(result.documentElement.children[0].getAttribute('r')).toBe('40');
   });
 });


### PR DESCRIPTION
This pull request primarily involves refactoring the `fetchDocument` function in `dev/popup.js` and adding tests for it in `dev/popup.test.js`. The `fetchDocument` function, which fetches a document from a specified URL and returns it as an SVG document, was moved out of the `getIcons` function and made available for export. Corresponding changes were made in the test file to include the `fetchDocument` function and a new test suite was added to test this function.

Refactoring:

* [`dev/popup.js`](diffhunk://#diff-5dd7e6f389caa90c0a93cfa8a86304e72bf4d07d66963acec9c432c8b92794dbR111-R123): The `fetchDocument` function was moved out of the `getIcons` function and made available for export. This change makes the `fetchDocument` function reusable and improves the readability of the `getIcons` function. [[1]](diffhunk://#diff-5dd7e6f389caa90c0a93cfa8a86304e72bf4d07d66963acec9c432c8b92794dbR111-R123) [[2]](diffhunk://#diff-5dd7e6f389caa90c0a93cfa8a86304e72bf4d07d66963acec9c432c8b92794dbL127-L135) [[3]](diffhunk://#diff-5dd7e6f389caa90c0a93cfa8a86304e72bf4d07d66963acec9c432c8b92794dbR727)

Testing:

* [`dev/popup.test.js`](diffhunk://#diff-a6f2b87f3271f8a8cf9986ba6b4f5dd6d9211e05bb3762236ebbbaa30d3bf903R10): The `fetchDocument` function was added to the import statement from `popup`. A new test suite `fetchDocument` was added to test the `fetchDocument` function. This ensures that the function fetches the document correctly and parses it into an SVG document. [[1]](diffhunk://#diff-a6f2b87f3271f8a8cf9986ba6b4f5dd6d9211e05bb3762236ebbbaa30d3bf903R10) [[2]](diffhunk://#diff-a6f2b87f3271f8a8cf9986ba6b4f5dd6d9211e05bb3762236ebbbaa30d3bf903R127-R153)